### PR TITLE
Fix an error while updating package (see desc)

### DIFF
--- a/util/DebianPackager.py
+++ b/util/DebianPackager.py
@@ -263,7 +263,7 @@ class DebianPackager(object):
                         DpkgPy.control_extract(self, deb_path, self.root + "Packages/" + folder +
                                                "/silica_data/scripts/")
                         # Remove the Control; it's not needed.
-                        os.remove(self.root + "Packages/" + folder + "/silica_data/scripts/Control")
+                        os.remove(self.root + "Packages/" + folder + "/silica_data/scripts/control")
                         if not os.listdir(self.root + "Packages/" + folder + "/silica_data/scripts/"):
                             os.rmdir(self.root + "Packages/" + folder + "/silica_data/scripts/")
 


### PR DESCRIPTION
Fix the removing operation to use the correct file name; When created, the script is called control, yet this call tries to remove a file called Control (note the capital C)